### PR TITLE
add conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: pyqstem
+  # this is nice, but only works once you have an initial annotated git tag
+  # version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version:  0.0.1
+
+source:
+  git_url: https://github.com/jacobjma/PyQSTEM
+  # git_tag:  (commit id or tag of release to build, defaults to master)
+  patches:
+    - setup_simplify.patch
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True   # [win and py<35]
+
+requirements:
+  build:
+    - cython
+    - fftw
+    - numpy
+    - python
+    - setuptools
+    - toolchain
+  run:
+    - ase
+    - fftw
+    - matplotlib
+    - numpy
+    - python
+    - scikit-image
+    - scipy
+
+test:
+  imports:
+    - pyqstem
+    - pyqstem.util
+    - pyqstem.potentials

--- a/conda.recipe/setup_simplify.patch
+++ b/conda.recipe/setup_simplify.patch
@@ -1,0 +1,81 @@
+diff --git a/setup.py b/setup.py
+index cbc16e7..94e7a1f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,53 +1,35 @@
+-try:
+-    from setuptools import setup
+-    from setuptools import Extension
+-except ImportError:
+-    from distutils.core import setup
+-    from distutils.extension import Extension
+-
+-from pkg_resources import get_build_platform
++from setuptools import setup
++from setuptools import Extension
+ from setuptools import find_packages
+ from Cython.Build import cythonize
+-import distutils
+ import numpy as np
+ import os
+ import sys
+ 
+-include_dirs = [np.get_include(),os.path.join(os.getcwd(), 'fftw'),os.path.join(os.getcwd(), 'source/')]
+-
+-if get_build_platform() == 'win32':
+-    if sys.version_info[0] == 3:
+-        library_dirs = ['fftw/win32']
+-    elif sys.version_info[0] == 2:
+-        library_dirs = ['fftw/win32/dll']
++include_dirs = [np.get_include(),
++                os.path.join(sys.prefix, 'include'),
++                os.path.join(os.getcwd(), 'source')]
+ 
+-    libraries = ['libfftw3-3', 'libfftw3f-3', 'libfftw3l-3']
+-elif get_build_platform() == 'win-amd64':
+-    if sys.version_info[0] == 3:
+-        library_dirs = ['fftw/win64']
+-    elif sys.version_info[0] == 2:
+-        library_dirs = ['fftw/win64/dll']
++sources = ['memory_fftw3.cpp', 'data_containers.cpp', 'imagelib_fftw3.cpp',
++           'stemlib.cpp', 'stemutil.cpp', 'fileio_fftw3.cpp', 'matrixlib.cpp', 'readparams.cpp']
+ 
+-    libraries = ['libfftw3-3', 'libfftw3f-3', 'libfftw3l-3']
+-else:
+-    library_dirs = []
+-    libraries = ['fftw3','fftw3f']
++sources = ['source/' + x for x in sources] + ['pyqstem/qstem_interface.pyx', 'pyqstem/QSTEM.cpp']
+ 
+-sources = ['memory_fftw3.cpp','data_containers.cpp','imagelib_fftw3.cpp',
+-          'stemlib.cpp','stemutil.cpp','fileio_fftw3.cpp','matrixlib.cpp','readparams.cpp']
++library_dirs = []
++libraries = ['fftw3', 'fftw3f']
++extra_compile_args = ['-std=c++11']
+ 
+-sources = ['source/' + x for x in sources]
+-
+-sources+=['pyqstem/qstem_interface.pyx','pyqstem/QSTEM.cpp']
++if sys.platform == 'win32':
++    extra_compile_args.append('-D MS_WIN64')
++    library_dirs.append(os.path.join(sys.prefix, 'Library', 'lib'))
+ 
+ setup(name='qstem',
+-        packages = find_packages(),
+-        ext_modules=cythonize(Extension('pyqstem.qstem_interface',
+-                    sources=sources,
+-                    library_dirs=library_dirs,
+-                    libraries=libraries,
+-                    include_dirs=include_dirs,
+-                    extra_compile_args=['-std=c++11','-D MS_WIN64'],
+-                    language='c++')),
+-
+-     )
++      packages=find_packages(),
++      ext_modules=cythonize(Extension('pyqstem.qstem_interface',
++                                      sources=sources,
++                                      library_dirs=library_dirs,
++                                      libraries=libraries,
++                                      include_dirs=include_dirs,
++                                      extra_compile_args=extra_compile_args,
++                                      language='c++'))
++      )


### PR DESCRIPTION
This recipe is not complete enough to submit to conda-forge, but it should be functional.  What remains to be done is:

1. tag a real release of PyQSTEM, and update the recipe to point at the github release tarball instead of the git_url
2. Fill in appropriate data in the "about" section

The conda-forge example provided at https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml may be helpful.

I have built this recipe on Mac and Windows.  Python 3.5+ only on windows, due to compiler constraints (no mixing VC++ runtimes).

To build this recipe:
- conda install conda-build
- conda build -c conda-forge (absolute or relative path to PyQSTEM)

We're taking advantage of conda-forge here, because they already have packages for ase and fftw, which makes packaging PyQSTEM much easier.