### PR TITLE
Updating setup.py to compile on recent macOS CLANG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='qstem',
                     library_dirs=library_dirs,
                     libraries=libraries,
                     include_dirs=include_dirs,
-                    extra_compile_args=['-std=c++11','-D MS_WIN64'],
+                    extra_compile_args=['-std=c++11','-stdlib=libc++','-D MS_WIN64'],
                     language='c++')),
 
      )


### PR DESCRIPTION
add compile flag "-stdlib=libc++" to allow the software to compile on Apple LLVM CLang 9.0.0, macOS 10.12.6